### PR TITLE
clean up some more docs

### DIFF
--- a/charts/libretranslate/README.md
+++ b/charts/libretranslate/README.md
@@ -1,6 +1,6 @@
 # libretranslate
 
-![Version: 0.4.1](https://img.shields.io/badge/Version-0.4.1-informational?style=flat-square)
+![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square)
 
 A Helm chart for Kubernetes to deploy LibreTranslate API
 
@@ -23,14 +23,14 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 | adminUser.secretKeys.name | string | `"name"` |  |
 | adminUser.secretKeys.password | string | `"password"` |  |
 | annotations | object | `{}` | Extra annotations |
-| appConfig.apiKeysDbPath | string | `"/app/db/api_keys.db"` | Use a specific path inside the container for the local database. Can be absolute or relative (Default: /app/db/api_keys.db) |
-| appConfig.apiKeysDbPathMount | string | `"/app/db"` | Use a specific path inside the container for the local database. Must be the same as apiKeysDbPath (Default: /app/db) |
+| appConfig.apiKeysDbPath | string | `"/app/db/api_keys.db"` | Use a specific path inside the container for the local database. Can be absolute or relative |
+| appConfig.apiKeysDbPathMount | string | `"/app/db"` | Use a specific path inside the container for the local database. Must be the same as apiKeysDbPath |
 | appConfig.apiKeysRemote | string | `""` | Use this remote endpoint to query for valid API keys instead of using the local database (Default: Empty (use local db instead)) |
 | appConfig.batchLimit | string | `"null"` | Set maximum number of texts to translate in a batch request (Default: No limit) |
 | appConfig.charLimit | string | `"null"` | Set character limit (Default: No limit) |
-| appConfig.frontendLanguageSource | string | `"auto"` | Set frontend default language - source (Default: auto) |
-| appConfig.frontendLanguageTarget | string | `"locale"` | Set frontend default language - target (Default: locale (match site's locale)) |
-| appConfig.frontendTimeout | string | `"500"` | Set frontend translation timeout (Default: 500) |
+| appConfig.frontendLanguageSource | string | `"auto"` | Set frontend default language - source |
+| appConfig.frontendLanguageTarget | string | `"locale"` | Set frontend default language - target. Default is to match site's locale |
+| appConfig.frontendTimeout | string | `"500"` | Set frontend translation timeout |
 | appConfig.gaId | string | `""` | Enable Google Analytics on the API client page by providing an ID (Default: Empty (no tracking)) |
 | appConfig.getApiKeyLink | string | `""` | Show a link in the UI where to direct users to get an API key (Default: Empty (no link shown on web ui)) |
 | appConfig.host | string | `"0.0.0.0"` | Set host to bind the server to (Default: 127.0.0.1) |
@@ -38,8 +38,8 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 | appConfig.metricsAuthToken | string | `""` | Protect the /metrics endpoint by allowing only clients that have a valid Authorization Bearer token (Default: Empty (no auth required)) |
 | appConfig.port | string | `"5000"` | Set port to bind the server to (Default: 5000) |
 | appConfig.reqLimit | string | `"null"` | Set maximum number of requests per minute per client (outside of limits set by api keys) (Default: No limit) |
-| appConfig.reqLimitStorage | string | `"memory://"` | Storage URI to use for request limit data storage. See Flask Limiter (Default: memory://) |
-| appConfig.sharedStorage | string | `"memory://"` | Shared storage URI to use for multi-process data sharing (e.g. when using gunicorn) (Default: memory://) |
+| appConfig.reqLimitStorage | string | `"memory://"` | Storage URI to use for request limit data storage. See Flask Limiter |
+| appConfig.sharedStorage | string | `"memory://"` | Shared storage URI to use for multi-process data sharing (e.g. when using gunicorn) |
 | appConfig.threads | string | `"4"` | Set number of threads (Default: 4) |
 | appConfig.urlPrefix | string | `""` | Add prefix to URL: example.com:5000/url-prefix/ (Default: /) |
 | appSettings.apiKeys | string | `"false"` |  |

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -24,7 +24,8 @@ image:
   pullPolicy: Always
   tag: "latest"
 # Using a Private Registry
-# If you want to use a custom image from a private registry, you'll need to create an image pull secret with the registry's credentials:
+# If you want to use a custom image from a private registry, you'll need to
+# create an image pull secret with the registry's credentials:
 # kubectl create secret docker-registry my-registry-secret --docker-server=DOCKER_REGISTRY_SERVER --docker-username=DOCKER_USER --docker-password=DOCKER_PASSWORD --docker-email=DOCKER_EMAIL
 # imagePullSecrets:
 #   - name: my-registry-secret
@@ -73,8 +74,9 @@ podSecurityContext:
   runAsGroup: 1032
 
 # Persistent settings
-# if you don't want to download a copy of the models per pod, you can use a shared storage like an nfs storage class
-# and set it to ReadWriteMany. this way if you scale the pods later on, they will all use the same models and won't
+# if you don't want to download a copy of the models per pod, you can use a
+# shared storage like an nfs storage class and set it to ReadWriteMany. this way
+# if you scale the pods later on, they will all use the same models and won't
 # duplicate the space and download requests.
 persistence:
   enabled: false
@@ -117,14 +119,11 @@ livenessProbe: {}
 #   periodSeconds: 5
 
 # Auth secret for basic authentication
-# generate base64-user-password-pair with:
-#   htpasswd -nb <username> <password> | base64
+# generate base64-user-password-pair: htpasswd -nb <username> <password> | base64
 #
-# e.g.:
-#
-#     htpasswd -nb admin mySecretPassword | base64
-# This is used by the nginx ingress controller to enable basic auth for the whole site.
-# It will create a secret with the name libretranslate-auth.
+# e.g.: htpasswd -nb admin mySecretPassword | base64
+# This is used by the nginx ingress controller to enable basic auth for the
+# whole site. It will create a secret with the name libretranslate-auth.
 adminUser:
   # -- copy the username in base64 as a reference
   name: "YWRtaW4K"
@@ -140,28 +139,33 @@ adminUser:
     auth: "auth"
     password: "password"
 
+
 # Settings / Flags
 appSettings:
   # -- Enable debug environment (Default: Disabled)
-  debug:                 "false"
+  debug: "false"
   # -- Enable SSL (Default: Disabled)
-  ssl:                   "false"
-  # -- Enable API keys database for per-client rate limits when --req-limit is reached (Default: Don't use API keys)
-  apiKeys:               "false"
-  # -- Require use of an API key for programmatic access to the API, unless the request origin matches this domain (Default: No restrictions on domain origin)
-  requireApiKeyOrigin:   ""
-  # -- Require use of an API key for programmatic access to the API, unless the client also sends a secret match (Default: No secrets required)
-  requireApiKeySecret:   ""
+  ssl: "false"
+  # -- Enable API keys database for per-client rate limits when --req-limit
+  # is reached (Default: Don't use API keys)
+  apiKeys: "false"
+  # -- Require use of an API key for programmatic access to the API, unless the
+  # request origin matches this domain (Default: No restrictions on domain origin)
+  requireApiKeyOrigin: ""
+  # -- Require use of an API key for programmatic access to the API, unless the
+  # client also sends a secret match (Default: No secrets required)
+  requireApiKeySecret: ""
   # -- Allow user suggestions (Default: Disabled)
-  suggestions:           "false"
+  suggestions: "false"
   # -- Disable files translation (Default: File translation allowed)
   disableFilesTranslation: "false"
   # -- Disable web ui (Default: Web Ui enabled)
-  disableWebUi:          "false"
+  disableWebUi: "false"
   # -- Update language models at startup (Default: Only on if no models found)
-  updateModels:          "false"
-  # -- Enable the /metrics endpoint for exporting Prometheus usage metrics (Default: Disabled)
-  metrics:               "false"
+  updateModels: "false"
+  # -- Enable the /metrics endpoint for exporting Prometheus usage metrics
+  # (Default: Disabled)
+  metrics: "false"
   # -- use an existing secret for api key origin and secret
   existingSecret: ""
   # keys in existing secret
@@ -173,40 +177,48 @@ appSettings:
 # Configuration Parameters
 appConfig:
   # -- Set host to bind the server to (Default: 127.0.0.1)
-  host:                  "0.0.0.0"
+  host: "0.0.0.0"
   # -- Set port to bind the server to (Default: 5000)
-  port:                  "5000"
+  port: "5000"
   # -- Set character limit (Default: No limit)
-  charLimit:             "null"
-  # -- Set maximum number of requests per minute per client (outside of limits set by api keys) (Default: No limit)
-  reqLimit:              "null"
-  # -- Storage URI to use for request limit data storage. See Flask Limiter (Default: memory://)
-  reqLimitStorage:       "memory://"
-  # -- Set maximum number of texts to translate in a batch request (Default: No limit)
-  batchLimit:            "null"
-  # -- Enable Google Analytics on the API client page by providing an ID (Default: Empty (no tracking))
-  gaId:                  ""
-  # -- Set frontend default language - source (Default: auto)
+  charLimit: "null"
+  # -- Set maximum number of requests per minute per client (outside of limits
+  # set by api keys) (Default: No limit)
+  reqLimit: "null"
+  # -- Storage URI to use for request limit data storage. See Flask Limiter
+  reqLimitStorage: "memory://"
+  # -- Set maximum number of texts to translate in a batch request
+  # (Default: No limit)
+  batchLimit: "null"
+  # -- Enable Google Analytics on the API client page by providing an ID
+  # (Default: Empty (no tracking))
+  gaId: ""
+  # -- Set frontend default language - source
   frontendLanguageSource: "auto"
-  # -- Set frontend default language - target (Default: locale (match site's locale))
+  # -- Set frontend default language - target. Default is to match site's locale
   frontendLanguageTarget: "locale"
-  # -- Set frontend translation timeout (Default: 500)
-  frontendTimeout:       "500"
-  # -- Use a specific path inside the container for the local database. Can be absolute or relative (Default: /app/db/api_keys.db)
-  apiKeysDbPath:         "/app/db/api_keys.db"
-  # -- Use a specific path inside the container for the local database. Must be the same as apiKeysDbPath (Default: /app/db)
-  apiKeysDbPathMount:    "/app/db"
-  # -- Use this remote endpoint to query for valid API keys instead of using the local database (Default: Empty (use local db instead))
-  apiKeysRemote:         ""
-  # --  Show a link in the UI where to direct users to get an API key (Default: Empty (no link shown on web ui))
-  getApiKeyLink:         ""
-  # -- Shared storage URI to use for multi-process data sharing (e.g. when using gunicorn) (Default: memory://)
-  sharedStorage:         "memory://"
+  # -- Set frontend translation timeout
+  frontendTimeout: "500"
+  # -- Use a specific path inside the container for the local database.
+  # Can be absolute or relative
+  apiKeysDbPath: "/app/db/api_keys.db"
+  # -- Use a specific path inside the container for the local database.
+  # Must be the same as apiKeysDbPath
+  apiKeysDbPathMount: "/app/db"
+  # -- Use this remote endpoint to query for valid API keys instead of using the
+  # local database (Default: Empty (use local db instead))
+  apiKeysRemote: ""
+  # --  Show a link in the UI where to direct users to get an API key
+  # (Default: Empty (no link shown on web ui))
+  getApiKeyLink: ""
+  # -- Shared storage URI to use for multi-process data sharing (e.g. when using gunicorn)
+  sharedStorage: "memory://"
   # -- Set available languages (Default: Empty (use all from argostranslate))
-  loadOnly:              ""
+  loadOnly: ""
   # -- Set number of threads (Default: 4)
-  threads:               "4"
-  # -- Protect the /metrics endpoint by allowing only clients that have a valid Authorization Bearer token (Default: Empty (no auth required))
-  metricsAuthToken:      ""
+  threads: "4"
+  # -- Protect the /metrics endpoint by allowing only clients that have a valid
+  # Authorization Bearer token (Default: Empty (no auth required))
+  metricsAuthToken: ""
   # -- Add prefix to URL: example.com:5000/url-prefix/ (Default: /)
-  urlPrefix:             ""
+  urlPrefix: ""


### PR DESCRIPTION
remove some defaults from comments, as they're already in the values.yaml and use new lines for comments over 80 characters so you can easily compare two files on the same screen, also removes unecessary whitespace