### PR TITLE
Features: add renovate, use default api key, add docs, allow existing PVC, and more

### DIFF
--- a/.github/renovate-config.json
+++ b/.github/renovate-config.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "onboarding": false,
+    "username": "renovate-release",
+    "gitAuthor": "Renovate Bot <bot@renovateapp.com>",
+    "platform": "github",
+    "repositories": [
+        "small-hack/libretranslate-helm-chart"
+    ],
+    "allowedPostUpgradeCommands": ["^scripts"]
+}

--- a/.github/workflows/ci-helm-lint-test.yml
+++ b/.github/workflows/ci-helm-lint-test.yml
@@ -1,0 +1,49 @@
+name: Lint and Test Chart
+
+on:
+  pull_request:
+    paths:
+      - 'charts/libretranslate/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run chart-testing (lint)
+        id: lint
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct lint --target-branch ${{ github.event.repository.default_branch }}
+
+      - uses: debianmaster/actions-k3s@master
+        id: k3s
+        with:
+          version: 'latest'
+
+      - name: Run chart-testing (install)
+        id: install
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+            ct install --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -8,39 +8,39 @@ on:
       - charts/libretranslate/**
 
 jobs:
-  bump-version:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+  # bump-version:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v2
 
-      - name: Install yq
-        run: sudo snap install yq
+  #     - name: Install yq
+  #       run: sudo snap install yq
 
-      - name: Bump Patch Version
-        run: |
-          # Read the current version
-          version=$(yq e '.version' charts/libretranslate/Chart.yaml)
+  #     - name: Bump Patch Version
+  #       run: |
+  #         # Read the current version
+  #         version=$(yq e '.version' charts/libretranslate/Chart.yaml)
 
-          # Split the version into major, minor, and patch
-          IFS='.' read -ra VERSION_PARTS <<< "$version"
+  #         # Split the version into major, minor, and patch
+  #         IFS='.' read -ra VERSION_PARTS <<< "$version"
 
-          # Increment the minor version
-          VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
+  #         # Increment the minor version
+  #         VERSION_PARTS[2]=$((VERSION_PARTS[2] + 1))
 
-          # Reassemble the version string
-          new_version="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
+  #         # Reassemble the version string
+  #         new_version="${VERSION_PARTS[0]}.${VERSION_PARTS[1]}.${VERSION_PARTS[2]}"
 
-          # Update the version in the Chart.yaml file
-          yq e ".version = \"$new_version\"" -i charts/libretranslate/Chart.yaml
+  #         # Update the version in the Chart.yaml file
+  #         yq e ".version = \"$new_version\"" -i charts/libretranslate/Chart.yaml
 
-      - name: Commit and Push
-        run: |
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
-          git add charts/libretranslate/Chart.yaml
-          git commit -m "Bump chart version"
-          git push
+  #     - name: Commit and Push
+  #       run: |
+  #         git config --global user.name 'GitHub Actions'
+  #         git config --global user.email 'actions@github.com'
+  #         git add charts/libretranslate/Chart.yaml
+  #         git commit -m "Bump chart version"
+  #         git push
 
   release:
     needs: bump-version

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,33 @@
+name: Renovate
+on:
+  workflow_dispatch:
+  schedule:
+    # This should be every hour
+    - cron: '0 * * * *'
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/renovate-config.json"
+      - ".github/workflows/renovate.yml"
+      - "renovate.json"
+      - "scripts/**"
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          private-key: ${{ secrets.PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+
+      - name: Checkout
+        uses: actions/checkout@v4.2.1
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@v40.3.4
+        with:
+          token: '${{ steps.app-token.outputs.token }}'
+          configurationFile: .github/renovate-config.json

--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ This Helm chart deploys a LibreTranslate instance on a Kubernetes cluster using 
 ### Prerequisites
 
 - Kubernetes 1.30+
-- Helm 3.6+
+- Helm 3.16+
 
 ## Updates from the forked repo include
 
-- using an existing persistent volume claim
-- using an existing Kubernetes Secret for a default API key
-- release notes in the GitHub Releases
-- setting the exact appVersion for the current version of LibreTranslate
+- using an existing Persistent Volume Claim
+- set a default api key
+  - using an existing Kubernetes Secret for a default API key
+- add automatic release notes in the GitHub Releases
+- use exact `appVersion` for the current version of the LibreTranslate docker image
 
 We will try to submit all of these changes upstream if the repo becomes maintained again.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # LibreTranslate Helm Chart
 
-This Helm chart deploys a LibreTranslate instance on a Kubernetes cluster using the Helm package manager.
+This Helm chart deploys a LibreTranslate instance on a Kubernetes cluster using the Helm package manager. This is a fork of [libretranslate/helm](https://github.com/libretranslate/helm) with some quality of life updates.
 
-## Prerequisites
+### Prerequisites
 
-- Kubernetes 1.12+
-- Helm 3.0+
+- Kubernetes 1.30+
+- Helm 3.6+
+
+## Updates from the forked repo include
+
+- using an existing persistent volume claim
+- using an existing Kubernetes Secret for a default API key
+- release notes in the GitHub Releases
+- setting the exact appVersion for the current version of LibreTranslate
+
+We will try to submit all of these changes upstream if the repo becomes maintained again.
 
 ## Setup helm chart repository
 

--- a/charts/libretranslate/Chart.yaml
+++ b/charts/libretranslate/Chart.yaml
@@ -2,8 +2,19 @@ apiVersion: v2
 name: libretranslate
 description: A Helm chart for Kubernetes to deploy LibreTranslate API
 home: https://libretranslate.github.io/helm-chart/
+
 sources:
   - https://github.com/LibreTranslate/LibreTranslate/
   - https://github.com/LibreTranslate/helm-chart/
+
 icon: https://libretranslate.com/static/favicon.ico
-version: 0.4.5
+
+maintainers:
+  - name: jessebot
+    url: https://github.com/jessebot
+
+# renovate: image=libretranslate/libretranslate
+appVersion: v1.6.2
+
+# version of the actual helm chart
+version: 0.5.0

--- a/charts/libretranslate/README.md
+++ b/charts/libretranslate/README.md
@@ -1,10 +1,16 @@
 # libretranslate
 
-![Version: 0.4.3](https://img.shields.io/badge/Version-0.4.3-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: v1.6.2](https://img.shields.io/badge/AppVersion-v1.6.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes to deploy LibreTranslate API
 
 **Homepage:** <https://libretranslate.github.io/helm-chart/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| jessebot |  | <https://github.com/jessebot> |
 
 ## Source Code
 
@@ -15,10 +21,10 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| adminUser.auth | string | `"YWRtaW46JGFwcjEkYlpydmYvUFYkSHBHSlhqZU1EN0ZON2kyYndsMVRNMQoK"` | copy the output from the htpasswd command here as a reference |
+| adminUser.auth | string | `""` | copy the output from the htpasswd command here as a reference, e.g. YWRtaW46JGFwcjEkYlpydmYvUFYkSHBHSlhqZU1EN0ZON2kyYndsMVRNMQoK |
 | adminUser.existingSecret | string | `""` | use an existing secret for admin user |
-| adminUser.name | string | `"YWRtaW4K"` | copy the username in base64 as a reference |
-| adminUser.password | string | `"bXlTZWNyZXRQYXNzd29yZAo="` | copy the password as base64 for the admin user here as a reference |
+| adminUser.name | string | `""` | copy the username in base64 as a reference, e.g. YWRtaW4K |
+| adminUser.password | string | `""` | copy the password as base64 for the admin user here as a reference e.g. bXlTZWNyZXRQYXNzd29yZAo= |
 | adminUser.secretKeys.auth | string | `"auth"` |  |
 | adminUser.secretKeys.name | string | `"name"` |  |
 | adminUser.secretKeys.password | string | `"password"` |  |
@@ -36,8 +42,8 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 | appConfig.host | string | `"0.0.0.0"` | Set host to bind the server to (Default: 127.0.0.1) |
 | appConfig.loadOnly | string | `""` | Set available languages (Default: Empty (use all from argostranslate)) |
 | appConfig.metricsAuthToken | string | `""` | Protect the /metrics endpoint by allowing only clients that have a valid Authorization Bearer token (Default: Empty (no auth required)) |
-| appConfig.port | string | `"5000"` | Set port to bind the server to (Default: 5000) |
-| appConfig.reqLimit | string | `"null"` | Set maximum number of requests per minute per client (outside of limits set by api keys) (Default: No limit) |
+| appConfig.port | string | `"5000"` | Set port to bind the server to |
+| appConfig.reqLimit | string | `"null"` | Set maximum number of requests per minute per client (outside of limits set by api keys). The default is "null" which means "no limit". If you set this to "null", and you provide an api key secret, we will set the default api key requests per minute to 120 by default, as you MUST set an api key limit |
 | appConfig.reqLimitStorage | string | `"memory://"` | Storage URI to use for request limit data storage. See Flask Limiter |
 | appConfig.sharedStorage | string | `"memory://"` | Shared storage URI to use for multi-process data sharing (e.g. when using gunicorn) |
 | appConfig.threads | string | `"4"` | Set number of threads (Default: 4) |
@@ -46,19 +52,19 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 | appSettings.debug | string | `"false"` | Enable debug environment (Default: Disabled) |
 | appSettings.disableFilesTranslation | string | `"false"` | Disable files translation (Default: File translation allowed) |
 | appSettings.disableWebUi | string | `"false"` | Disable web ui (Default: Web Ui enabled) |
-| appSettings.existingSecret | string | `""` | use an existing secret for api key origin and secret |
+| appSettings.existingSecret | string | `""` | use an existing Kubernetes Secret for api key origin and secret |
 | appSettings.metrics | string | `"false"` | Enable the /metrics endpoint for exporting Prometheus usage metrics (Default: Disabled) |
 | appSettings.requireApiKeyOrigin | string | `""` | Require use of an API key for programmatic access to the API, unless the request origin matches this domain (Default: No restrictions on domain origin) |
-| appSettings.requireApiKeySecret | string | `""` | Require use of an API key for programmatic access to the API, unless the client also sends a secret match (Default: No secrets required) |
-| appSettings.secretKeys.apiKeyorigin | string | `""` |  |
-| appSettings.secretKeys.apiKeysecret | string | `"secret"` |  |
+| appSettings.requireApiKeySecret | string | `""` | Set this to an api key secret you'd like to use, or an existing k8s Secret use appSettings.existingSecret and appSettings.secretKeys.apiKeySecret. This currently acts as the default API Key. Uses appConfig.reqLimit as the default requests per minute. If you do not set appConfig.reqLimit (or leave it as "null"), the default requests per minute is 120 |
+| appSettings.secretKeys.apiKeyOrigin | string | `""` | key in existing Kubernetes Secret for api key origin. If set, ignores appSettings.requireApiKeyOrigin |
+| appSettings.secretKeys.apiKeySecret | string | `"secret"` | key in existing Kubernetes Secret for api key secret. If set, ignores appSettings.requireApiKeySecret |
 | appSettings.ssl | string | `"false"` | Enable SSL (Default: Disabled) |
 | appSettings.suggestions | string | `"false"` | Allow user suggestions (Default: Disabled) |
 | appSettings.updateModels | string | `"false"` | Update language models at startup (Default: Only on if no models found) |
 | fullnameOverride | string | `""` | Full name of the deployment to override the default one |
-| image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"libretranslate/libretranslate"` |  |
-| image.tag | string | `"latest"` |  |
+| image.pullPolicy | string | `"IfNotPresent"` | if you set the image tag to latest, set the pull policy to "latest" |
+| image.repository | string | `"libretranslate/libretranslate"` | default image is pulled from docker hub |
+| image.tag | string | `""` | this defaults to appVersion in Chart.yaml, but you can override it |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"10m"` |  |
 | ingress.className | string | `""` | set this to the name of the ingress controller class to use like nginx |
@@ -71,10 +77,12 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 | livenessProbe | object | `{}` | Liveness probe for kubernetes |
 | nameOverride | string | `""` | Chart name override |
 | persistence.db.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.db.existingClaim | string | `""` | use an existing persistent volume claim for the database. Setting this will ignore all other persistence.db parameters |
 | persistence.db.size | string | `"1Gi"` |  |
 | persistence.db.storageClass | string | `""` |  |
 | persistence.enabled | bool | `false` |  |
 | persistence.models.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.models.existingClaim | string | `""` | use an existing persistent volume claim for the models. Setting this will ignore all other persistence.models parameters |
 | persistence.models.size | string | `"10Gi"` | as of August 2023, the models are about 6.6GB in size for all languages |
 | persistence.models.storageClass | string | `""` |  |
 | podAnnotations | object | `{}` | Extra annotations for pods |

--- a/charts/libretranslate/templates/statefulset.yaml
+++ b/charts/libretranslate/templates/statefulset.yaml
@@ -42,25 +42,55 @@ spec:
       {{- if .Values.persistence.enabled }}
       initContainers:
         - name: volume-permissions-and-pre-install-models
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           command:
-          - /bin/bash
-          - -c
-          - |
-            mkdir -p /home/libretranslate/.local/share/argos-translate/packages
-            chown -R 1032:1032 /home/libretranslate/.local /app/db
+            - /bin/bash
+            - -c
+            - |
+              mkdir -p /home/libretranslate/.local/share/argos-translate/packages
+              chown -R 1032:1032 /home/libretranslate/.local /app/db
 
-            if [ ! "$(ls -A /home/libretranslate/.local/share/argos-translate/packages)" ]; then
-              echo "Installing models... this can take quite a while depending on your internet connection."
-              /app/venv/bin/python /app/scripts/install_models.py --load_only_lang_codes {{ .Values.appConfig.loadOnly | quote }}
-            else
-              echo "The models directory is not empty, skipping model installation."
-            fi
+              if [ ! "$(ls -A /home/libretranslate/.local/share/argos-translate/packages)" ]; then
+                echo "Installing models... this can take quite a while depending on your internet connection."
+                /app/venv/bin/python /app/scripts/install_models.py --load_only_lang_codes {{ .Values.appConfig.loadOnly | quote }}
+              else
+                echo "The models directory is not empty, skipping model installation."
+              fi
+
+              {{- if or .Values.appSettings.requireApiKeySecret (and .Values.appSettings.existingSecret .Values.appSettings.secretKeys.apiKeysecret) }}
+              if [[ ${LT_REQUIRE_API_KEY_SECRET} != "null" ]; then
+                echo "Setting up your default api key..."
+                ltmanage keys add --key ${LT_REQUIRE_API_KEY_SECRET} ${DEFAULT_API_KEY_LIMIT} || echo "something went wrong with adding the api key"
+              fi
+              {{- end }}
           volumeMounts:
-          - name: models-volume
-            mountPath: /home/libretranslate/.local/share/argos-translate
-          - name: db-volume
-            mountPath: {{ .Values.appConfig.apiKeysDbPathMount }}
+            - name: models-volume
+              mountPath: /home/libretranslate/.local/share/argos-translate
+            - name: db-volume
+              mountPath: {{ .Values.appConfig.apiKeysDbPathMount }}
+          {{- if or .Values.appSettings.requireApiKeySecret (and .Values.appSettings.existingSecret .Values.appSettings.secretKeys.apiKeysecret) }}
+          env:
+            - name: LT_REQUIRE_API_KEY_SECRET
+              valueFrom:
+                secretKeyRef:
+                {{- if not .Values.appSettings.existingSecret }}
+                  name: {{ include "libretranslate.fullname" . }}-api-key
+                  key: requireApiKeySecret
+                {{- else }}
+                  name: {{ .Values.appSettings.existingSecret }}
+                  key: {{ .Values.appSettings.secretKeys.apiKeysecret }}
+                {{- end }}
+            {{- if (ne .Values.appConfig.reqLimit "null") }}
+            - name: DEFAULT_API_KEY_LIMIT
+              valueFrom:
+                configMapKeyRef:
+                  name: libretranslate-config
+                  key: reqLimit
+            {{- else }}
+            - name: DEFAULT_API_KEY_LIMIT
+              value: "120"
+            {{- end }}
+          {{- end }}
           {{- if .Values.initContainerSecurityContext }}
           securityContext:
             # forces the mount of the volumes to be mounted as libretranslate user and group
@@ -70,7 +100,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -79,10 +109,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           securityContext:
-            {{- if .Values.podSecurityContext }}
-            # forces the mount of the volumes to be mounted as libretranslate user and group
-            # and set permissions to libretranslate:libretranslate
-              {{- toYaml .Values.podSecurityContext | nindent 12 }}
+            {{- with .Values.podSecurityContext }}
+              # forces the mount of the volumes to be mounted as libretranslate user and group
+              # and set permissions to libretranslate:libretranslate
+              {{- toYaml . | nindent 12 }}
             {{- end }}
             allowPrivilegeEscalation: false
           {{- with .Values.readinessProbe }}
@@ -308,17 +338,25 @@ spec:
           - name: models-volume
             mountPath: /home/libretranslate/.local/share/argos-translate
           {{- end }}
-      {{- if and .Values.persistence.enabled (or (eq .Values.persistence.models.accessMode "ReadWriteMany") (eq .Values.persistence.db.accessMode "ReadWriteMany")) }}
+      {{- if and .Values.persistence.enabled (or (eq .Values.persistence.models.accessMode "ReadWriteMany") (eq .Values.persistence.db.accessMode "ReadWriteMany") .Values.persistence.db.existingClaim .Values.persistence.models.existingClaim ) }}
       volumes:
       {{- if eq .Values.persistence.db.accessMode "ReadWriteMany" }}
       - name: db-volume
         persistentVolumeClaim:
+          {{- if .Values.persistence.db.existingClaim }}
+          claimName: {{ .Values.persistence.db.existingClaim }}
+          {{- else }}
           claimName: db-volume
+          {{- end }}
       {{- end }}
       {{- if eq .Values.persistence.models.accessMode "ReadWriteMany" }}
       - name: models-volume
         persistentVolumeClaim:
+          {{- if .Values.persistence.models.existingClaim }}
+          claimName: {{ .Values.persistence.models.existingClaim }}
+          {{- else }}
           claimName: models-volume
+          {{- end }}
       {{- end }}
       {{- end }}
       {{- if .Values.tolerations }}

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -1,4 +1,4 @@
-# values.yaml
+# values.yaml for the libretranslate helm chart
 
 # -- Number of replicas
 replicaCount: 1
@@ -20,9 +20,12 @@ fullnameOverride: ""
 
 # Image settings
 image:
+  # -- default image is pulled from docker hub
   repository: libretranslate/libretranslate
-  pullPolicy: Always
-  tag: "latest"
+  # -- if you set the image tag to latest, set the pull policy to "latest"
+  pullPolicy: IfNotPresent
+  # -- this defaults to appVersion in Chart.yaml, but you can override it
+  tag: ""
 # Using a Private Registry
 # If you want to use a custom image from a private registry, you'll need to
 # create an image pull secret with the registry's credentials:
@@ -84,11 +87,17 @@ persistence:
     storageClass: ""
     accessMode: "ReadWriteOnce"
     size: "1Gi"
+    # -- use an existing persistent volume claim for the database. Setting this
+    # will ignore all other persistence.db parameters
+    existingClaim: ""
   models:
     storageClass: ""
     accessMode: "ReadWriteOnce"
     # -- as of August 2023, the models are about 6.6GB in size for all languages
     size: "10Gi"
+    # -- use an existing persistent volume claim for the models. Setting this
+    # will ignore all other persistence.models parameters
+    existingClaim: ""
 
 
 # Resource limits
@@ -125,12 +134,14 @@ livenessProbe: {}
 # This is used by the nginx ingress controller to enable basic auth for the
 # whole site. It will create a secret with the name libretranslate-auth.
 adminUser:
-  # -- copy the username in base64 as a reference
-  name: "YWRtaW4K"
-  # -- copy the output from the htpasswd command here as a reference
-  auth: "YWRtaW46JGFwcjEkYlpydmYvUFYkSHBHSlhqZU1EN0ZON2kyYndsMVRNMQoK"
+  # -- copy the username in base64 as a reference, e.g. YWRtaW4K
+  name: ""
+  # -- copy the output from the htpasswd command here as a reference,
+  # e.g. YWRtaW46JGFwcjEkYlpydmYvUFYkSHBHSlhqZU1EN0ZON2kyYndsMVRNMQoK
+  auth: ""
   # -- copy the password as base64 for the admin user here as a reference
-  password: "bXlTZWNyZXRQYXNzd29yZAo="
+  # e.g. bXlTZWNyZXRQYXNzd29yZAo=
+  password: ""
   # -- use an existing secret for admin user
   existingSecret: ""
   # key in existing secret
@@ -152,8 +163,11 @@ appSettings:
   # -- Require use of an API key for programmatic access to the API, unless the
   # request origin matches this domain (Default: No restrictions on domain origin)
   requireApiKeyOrigin: ""
-  # -- Require use of an API key for programmatic access to the API, unless the
-  # client also sends a secret match (Default: No secrets required)
+  # -- Set this to an api key secret you'd like to use, or an existing k8s Secret
+  # use appSettings.existingSecret and appSettings.secretKeys.apiKeySecret. This
+  # currently acts as the default API Key. Uses appConfig.reqLimit as the default
+  # requests per minute. If you do not set appConfig.reqLimit (or leave it as "null"),
+  # the default requests per minute is 120
   requireApiKeySecret: ""
   # -- Allow user suggestions (Default: Disabled)
   suggestions: "false"
@@ -166,24 +180,30 @@ appSettings:
   # -- Enable the /metrics endpoint for exporting Prometheus usage metrics
   # (Default: Disabled)
   metrics: "false"
-  # -- use an existing secret for api key origin and secret
+  # -- use an existing Kubernetes Secret for api key origin and secret
   existingSecret: ""
-  # keys in existing secret
+  # keys in an existing Kubernetes Secret
   secretKeys:
-    apiKeyorigin: ""
-    apiKeysecret: "secret"
+    # -- key in existing Kubernetes Secret for api key origin. If set,
+    # ignores appSettings.requireApiKeyOrigin
+    apiKeyOrigin: ""
+    # -- key in existing Kubernetes Secret for api key secret. If set,
+    # ignores appSettings.requireApiKeySecret
+    apiKeySecret: "secret"
 
 
 # Configuration Parameters
 appConfig:
   # -- Set host to bind the server to (Default: 127.0.0.1)
   host: "0.0.0.0"
-  # -- Set port to bind the server to (Default: 5000)
+  # -- Set port to bind the server to
   port: "5000"
   # -- Set character limit (Default: No limit)
   charLimit: "null"
   # -- Set maximum number of requests per minute per client (outside of limits
-  # set by api keys) (Default: No limit)
+  # set by api keys). The default is "null" which means "no limit". If you set
+  # this to "null", and you provide an api key secret, we will set the default
+  # api key requests per minute to 120 by default, as you MUST set an api key limit
   reqLimit: "null"
   # -- Storage URI to use for request limit data storage. See Flask Limiter
   reqLimitStorage: "memory://"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+          "config:recommended", ":disableDependencyDashboard"
+    ],
+    "customManagers": [
+        {
+          "customType": "regex",
+          "datasourceTemplate": "docker",
+          "fileMatch": [
+            "(^|/)Chart\\.yaml$"
+          ],
+          "matchStrings": [
+            "#\\s*renovate: image=(?<depName>.*?)\\s+appVersion:\\s*[\"']?(?<currentValue>[\\w+\\.\\-]*)"
+          ]
+        }
+    ],
+    "packageRules": [
+      {
+        "description": "Fix subchart archives for helm chart",
+        "matchManagers": ["helmv3"],
+        "postUpdateOptions": ["helmUpdateSubChartArchives"]
+      },
+      {
+        "description": "Fix version in Chart.yaml after helmv3 dep patch updates",
+        "matchManagers": ["helmv3"],
+        "matchUpdateTypes": ["patch"],
+        "bumpVersion": "patch"
+      },
+      {
+        "description": "Fix version in Chart.yaml after helmv3 dep minor updates",
+        "matchManagers": ["helmv3"],
+        "matchUpdateTypes": ["minor"],
+        "bumpVersion": "minor"
+      },
+      {
+        "description": "Fix version in Chart.yaml after helmv3 dep major updates",
+        "matchManagers": ["helmv3"],
+        "matchUpdateTypes": ["major"],
+        "bumpVersion": "major"
+      },
+      {
+        "description": "Bump helm chart versions by a patch when updating values files. This can be removed when https://github.com/renovatebot/renovate/issues/8231 is implemented and enabled.",
+        "matchManagers": ["helm-values", "regex"],
+        "postUpgradeTasks": {
+          "commands": [
+            "scripts/bump-chart-version.sh '{{{updateType}}}'"
+          ],
+          "fileFilters": ["**/Chart.yaml"],
+          "executionMode": "branch"
+        }
+      },
+      { 
+        "matchManagers": ["github-actions"],
+        "matchUpdateTypes": ["patch", "minor"],
+        "automerge": true
+      }
+    ]
+}

--- a/scripts/bump-chart-version.sh
+++ b/scripts/bump-chart-version.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# thanks to original comment: https://github.com/renovatebot/renovate/issues/8231#issuecomment-1978929997
+# converted to discussion: https://github.com/renovatebot/renovate/discussions/28861#discussioncomment-9326722
+
+set -euo pipefail
+
+update_type="$1"
+
+version=$(grep "^version:" "charts/libretranslate/Chart.yaml" | awk '{print $2}')
+
+if [[ ! $version ]]; then
+  echo "No valid version was found"
+  exit 1
+fi
+
+major=$(echo "$version" | cut -d. -f1)
+minor=$(echo "$version" | cut -d. -f2)
+patch=$(echo "$version" | cut -d. -f3)
+
+if [[ "$update_type" =~ (major|replacement) ]]; then
+  major=$(( major + 1 ))
+  minor=0
+  patch=0
+elif [[ "$update_type" =~ 'minor' ]]; then
+  minor=$(( minor + 1 ))
+  patch=0
+else
+  patch=$(( patch + 1 ))
+fi
+
+echo "Bumping version for libretranslate chart from $version to $major.$minor.$patch"
+sed -i "s/^version:.*/version: ${major}.${minor}.${patch}/g" "charts/libretranslate/Chart.yaml"


### PR DESCRIPTION
# Changes

- add docs on what's changed since the fork in README.md
- add chart testing workflow for new changes (will run in PRs)
- add myself as a maintainer in Chart.yaml
- temporarily disable automatic Chart.yaml version bumping, since it only does minor versions. (Will add back to PR workflow with additional version capabilities later)
- pin the appVersion in Chart.yaml to the current version of the libretranslate docker image
- Use renovate to automatically update the libretranslate verison as it gets out of date
- change `appSettings.secretKeys.apiKeysecret` to `appSettings.secretKeys.apiKeySecret`
- change `appSettings.secretKeys.apiKeyorigin` to `appSettings.secretKeys.apiKeyOrigin`
- allow using an existing PVC for database and models volumes with:
  ```yaml
  persistence:
    enabled: true
    db:
      existingClaim: "my-existing-db-claim"
    models:
      existingClaim: "my-existing-models-claim"
  ```
- use an init container to set the default api key for the instance, if one is passed in, which you can do via this:
  ```yaml
  appSettings:
    # -- Set this to an api key secret you'd like to use, or an existing k8s Secret
    # use appSettings.existingSecret and appSettings.secretKeys.apiKeySecret. This
    # currently acts as the default API Key. Uses appConfig.reqLimit as the default
    # requests per minute. If you do not set appConfig.reqLimit (or leave it as "null"),
    # the default requests per minute is 120
    requireApiKeySecret: ""
  ```
  or this:
  ```yaml
  appSettings:
    # -- use an existing Kubernetes Secret for api key origin and secret
    existingSecret: "my-existing-kubernetes-secret"
    # keys in an existing Kubernetes Secret
    secretKeys:
      # -- key in existing Kubernetes Secret for api key secret. If set,
      # ignores appSettings.requireApiKeySecret
      apiKeySecret: "secret"
  ```