### PR TITLE
clean up persistence handling (use existingClaim settings instead of checking accessMode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Helm chart deploys a LibreTranslate instance on a Kubernetes cluster using 
 ## Updates from the forked repo include
 
 - using an existing Persistent Volume Claim
+  - we now use `persistence.db.existingClaim` and `persistence.models.existingClaim` instead of relying on the ReadWriteMany check
 - set a default api key
   - using an existing Kubernetes Secret for a default API key
 - add automatic release notes in the GitHub Releases

--- a/charts/libretranslate/Chart.yaml
+++ b/charts/libretranslate/Chart.yaml
@@ -17,4 +17,4 @@ maintainers:
 appVersion: v1.6.2
 
 # version of the actual helm chart
-version: 0.5.0
+version: 0.6.0

--- a/charts/libretranslate/README.md
+++ b/charts/libretranslate/README.md
@@ -1,6 +1,6 @@
 # libretranslate
 
-![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![AppVersion: v1.6.2](https://img.shields.io/badge/AppVersion-v1.6.2-informational?style=flat-square)
+![Version: 0.6.0](https://img.shields.io/badge/Version-0.6.0-informational?style=flat-square) ![AppVersion: v1.6.2](https://img.shields.io/badge/AppVersion-v1.6.2-informational?style=flat-square)
 
 A Helm chart for Kubernetes to deploy LibreTranslate API
 
@@ -76,12 +76,12 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 | initContainerSecurityContext.runAsUser | int | `0` |  |
 | livenessProbe | object | `{}` | Liveness probe for kubernetes |
 | nameOverride | string | `""` | Chart name override |
-| persistence.db.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.db.accessMode | string | `""` |  |
 | persistence.db.existingClaim | string | `""` | use an existing persistent volume claim for the database. Setting this will ignore all other persistence.db parameters |
 | persistence.db.size | string | `"1Gi"` |  |
 | persistence.db.storageClass | string | `""` |  |
 | persistence.enabled | bool | `false` |  |
-| persistence.models.accessMode | string | `"ReadWriteOnce"` |  |
+| persistence.models.accessMode | string | `""` |  |
 | persistence.models.existingClaim | string | `""` | use an existing persistent volume claim for the models. Setting this will ignore all other persistence.models parameters |
 | persistence.models.size | string | `"10Gi"` | as of August 2023, the models are about 6.6GB in size for all languages |
 | persistence.models.storageClass | string | `""` |  |
@@ -95,7 +95,7 @@ A Helm chart for Kubernetes to deploy LibreTranslate API
 | resources.requests.cpu | string | `"500m"` |  |
 | resources.requests.memory | string | `"1Gi"` |  |
 | securityContext.fsGroup | int | `1032` |  |
-| service.port | int | `5000` |  |
+| service.port | int | `5000` | targetPort for the service. If you update this, you also need to update appConfig.port to match |
 | service.type | string | `"ClusterIP"` |  |
 | tolerations | list | `[]` | Extra tolerations for pods |
 

--- a/charts/libretranslate/templates/statefulset.yaml
+++ b/charts/libretranslate/templates/statefulset.yaml
@@ -338,65 +338,57 @@ spec:
           - name: models-volume
             mountPath: /home/libretranslate/.local/share/argos-translate
           {{- end }}
-      {{- if and .Values.persistence.enabled (or (eq .Values.persistence.models.accessMode "ReadWriteMany") (eq .Values.persistence.db.accessMode "ReadWriteMany") .Values.persistence.db.existingClaim .Values.persistence.models.existingClaim ) }}
+      {{- if and .Values.persistence.enabled (or .Values.persistence.db.existingClaim .Values.persistence.models.existingClaim) }}
       volumes:
-      {{- if eq .Values.persistence.db.accessMode "ReadWriteMany" }}
-      - name: db-volume
-        persistentVolumeClaim:
-          {{- if .Values.persistence.db.existingClaim }}
-          claimName: {{ .Values.persistence.db.existingClaim }}
-          {{- else }}
-          claimName: db-volume
-          {{- end }}
-      {{- end }}
-      {{- if eq .Values.persistence.models.accessMode "ReadWriteMany" }}
-      - name: models-volume
-        persistentVolumeClaim:
-          {{- if .Values.persistence.models.existingClaim }}
-          claimName: {{ .Values.persistence.models.existingClaim }}
-          {{- else }}
-          claimName: models-volume
-          {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- if .Values.tolerations }}
+        {{- with .Values.persistence.db.existingClaim }}
+        - name: db-volume
+          persistentVolumeClaim:
+            claimName: {{ . }}
+        {{- end }}
+        {{- with .Values.persistence.models.existingClaim }}
+        - name: models-volume
+          persistentVolumeClaim:
+            claimName: {{ . }}
+        {{- end }}
+        {{- end }}{{/* end existingClaim checks */}}
+      {{- with .Values.tolerations }}
       tolerations:
-      {{- toYaml .Values.tolerations   | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
       {{- end }}
-  {{- if and .Values.persistence.enabled (or (eq .Values.persistence.models.accessMode "ReadWriteOnce") (eq .Values.persistence.db.accessMode "ReadWriteOnce")) }}
+  {{- if and .Values.persistence.enabled (or (not .Values.persistence.models.existingClaim) (not .Values.persistence.db.existingClaim)) }}
   # still in beta, but this will allow us to delete the volumes when the statefulset is scaled down
   persistentVolumeClaimRetentionPolicy:
     whenDeleted: Retain
     whenScaled: Delete
   volumeClaimTemplates:
-  {{- if eq .Values.persistence.models.accessMode "ReadWriteOnce" }}
-  - metadata:
-      name: models-volume
-      labels:
-        {{- include "libretranslate.labels" . | nindent 8 }}
-    spec:
-      accessModes:
-        - {{ .Values.persistence.models.accessMode }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.models.size }}
-      {{- if .Values.persistence.models.storageClass }}
-      storageClassName: {{ .Values.persistence.models.storageClass | quote }}
-      {{- end }}
-  {{- end }}
-  {{- if eq .Values.persistence.db.accessMode "ReadWriteOnce" }}
-  - metadata:
-      name: db-volume
-      labels:
-        {{- include "libretranslate.labels" . | nindent 8 }}
-    spec:
-      accessModes:
-        - {{ .Values.persistence.db.accessMode }}
-      resources:
-        requests:
-          storage: {{ .Values.persistence.db.size }}
-      {{- if .Values.persistence.db.storageClass }}
-      storageClassName: {{ .Values.persistence.db.storageClass | quote }}
-      {{- end }}
-  {{- end }}
+    {{- if not .Values.persistence.models.existingClaim }}
+    - metadata:
+        name: models-volume
+        labels:
+          {{- include "libretranslate.labels" . | nindent 8 }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.models.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.models.size }}
+        {{- with .Values.persistence.models.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+    {{- end }}
+    {{- if not .Values.persistence.db.existingClaim }}
+    - metadata:
+        name: db-volume
+        labels:
+          {{- include "libretranslate.labels" . | nindent 8 }}
+      spec:
+        accessModes:
+          - {{ .Values.persistence.db.accessMode }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.db.size }}
+        {{- with .Values.persistence.db.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+    {{- end }}
   {{- end }}

--- a/charts/libretranslate/values.yaml
+++ b/charts/libretranslate/values.yaml
@@ -26,6 +26,7 @@ image:
   pullPolicy: IfNotPresent
   # -- this defaults to appVersion in Chart.yaml, but you can override it
   tag: ""
+
 # Using a Private Registry
 # If you want to use a custom image from a private registry, you'll need to
 # create an image pull secret with the registry's credentials:
@@ -37,6 +38,8 @@ imagePullSecrets: []
 # Service settings
 service:
   type: ClusterIP
+  # -- targetPort for the service. If you update this,
+  # you also need to update appConfig.port to match
   port: 5000
 
 # Ingress settings
@@ -77,22 +80,21 @@ podSecurityContext:
   runAsGroup: 1032
 
 # Persistent settings
-# if you don't want to download a copy of the models per pod, you can use a
-# shared storage like an nfs storage class and set it to ReadWriteMany. this way
-# if you scale the pods later on, they will all use the same models and won't
-# duplicate the space and download requests.
 persistence:
+  # enable persistence
   enabled: false
+
   db:
     storageClass: ""
-    accessMode: "ReadWriteOnce"
+    accessMode: ""
     size: "1Gi"
     # -- use an existing persistent volume claim for the database. Setting this
     # will ignore all other persistence.db parameters
     existingClaim: ""
+
   models:
     storageClass: ""
-    accessMode: "ReadWriteOnce"
+    accessMode: ""
     # -- as of August 2023, the models are about 6.6GB in size for all languages
     size: "10Gi"
     # -- use an existing persistent volume claim for the models. Setting this


### PR DESCRIPTION
# Changes

If you want to use an existing Persistent Volume Claim: instead of setting `persistence.db.accessMode` and `persistence.models.accessMode` to `ReadWriteMany`, you just set `persistence.db.existingClaim` and `persistence.models.existingClaim`. The reason behind this is that you can now specify the name of your existing claim and the the accessMode independently.

I also went through and fixed some more spacing issues with the persistence section of the StatefulSet.